### PR TITLE
Add Fly.io deployment config and CI deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,20 +126,3 @@ jobs:
           path: passwords/app/playwright-report/
           retention-days: 7
 
-  deploy-api:
-    name: Deploy API to Fly.io
-    runs-on: ubuntu-latest
-    needs: [rust-tests, js-tests, e2e-tests]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    defaults:
-      run:
-        working-directory: passwords/api
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to Fly.io
-        run: flyctl deploy
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
-      - name: Build frontend
-        run: npm run build
-
   e2e-tests:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master, passwords/master]
+    branches: [main]
     paths:
       - "passwords/**"
   push:
-    branches: [main, master, passwords/master]
+    branches: [main]
     paths:
       - "passwords/**"
 
@@ -133,7 +133,7 @@ jobs:
     name: Deploy API to Fly.io
     runs-on: ubuntu-latest
     needs: [rust-tests, js-tests, e2e-tests]
-    if: github.ref == 'refs/heads/passwords/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     defaults:
       run:
         working-directory: passwords/api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Build frontend
+        run: npm run build
+
   e2e-tests:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
@@ -125,3 +128,21 @@ jobs:
           name: playwright-report
           path: passwords/app/playwright-report/
           retention-days: 7
+
+  deploy-api:
+    name: Deploy API to Fly.io
+    runs-on: ubuntu-latest
+    needs: [rust-tests, js-tests, e2e-tests]
+    if: github.ref == 'refs/heads/passwords/master' && github.event_name == 'push'
+    defaults:
+      run:
+        working-directory: passwords/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/passwords/.github/copilot-instructions.md
+++ b/passwords/.github/copilot-instructions.md
@@ -236,11 +236,11 @@ When proposing a change that affects crypto, auth, or data formats:
 
 ### Branching
 
-- The main branch for this project is **`passwords/master`**.
+- The main branch for this project is **`main`**.
 - Feature branches should be named `xumaple/<feature>` when the user drives
   most of the work, or `xumaple/copilot/<feature>` when Copilot does the
   majority of the implementation.
-- PRs should target `passwords/master`.
+- PRs should target `main`.
 - **Start from a clean base.** Before beginning new work, make sure you are
   on the main branch with the latest changes. If there are uncommitted
   changes, stash them first (`git stash`), switch to main and pull, then

--- a/passwords/api/.dockerignore
+++ b/passwords/api/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.env
+.git/
+.gitignore
+Dockerfile
+.dockerignore

--- a/passwords/api/Dockerfile
+++ b/passwords/api/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Install cargo-chef
+FROM rust:1-slim-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+# Stage 2: Prepare dependency recipe
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Build dependencies then the application
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin passwords
+
+# Stage 4: Minimal runtime image
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/passwords /usr/local/bin/passwords
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/passwords"]

--- a/passwords/api/fly.toml
+++ b/passwords/api/fly.toml
@@ -1,0 +1,29 @@
+# fly.toml app configuration file generated for mapopass-api on 2026-03-31T01:30:11-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'mapopass-api'
+primary_region = 'ord'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/api/v2/generate'
+
+[[vm]]
+  memory = '256mb'
+  cpus = 1
+  memory_mb = 256

--- a/passwords/app/src/App.js
+++ b/passwords/app/src/App.js
@@ -16,8 +16,7 @@ export default function App() {
   let [aesKey, setAesKey] = useState("");
   let [en_pw, setEnPw] = useState("");
 
-  // const backend = "https://passwords.maplexu.me";
-  const backend = "http://localhost:8000";
+  const backend = process.env.REACT_APP_BACKEND_URL || "http://localhost:8000";
 
   const setAccountInfo = (user, en_user, derivedAesKey, en_pw) => {
     setUsername(user);


### PR DESCRIPTION
## Summary
- Add Dockerfile (multi-stage with cargo-chef) and fly.toml for deploying the API to Fly.io
- Add .dockerignore for clean Docker builds
- Frontend API URL now reads from `REACT_APP_BACKEND_URL` env var with localhost fallback
- CI now verifies frontend builds and auto-deploys to Fly.io on push to main

## Test plan
- [ ] Verify `fly deploy` succeeds from `passwords/api/`
- [ ] Verify frontend builds cleanly in CI
- [ ] Verify local dev still works with localhost fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)