### PR TITLE
Refactor CI into reusable workflows and gate deploy behind tests

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -1,0 +1,61 @@
+name: E2E Tests
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    env:
+      MONGO_USER: ${{ secrets.MONGO_USER }}
+      MONGO_PW: ${{ secrets.MONGO_PW }}
+      MONGO_ENDPOINT: ${{ secrets.MONGO_ENDPOINT }}
+      USERS_DB_NAME: ${{ secrets.USERS_DB_NAME }}
+      FRONTEND_ORIGIN: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            passwords/api/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('passwords/api/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build API (debug)
+        working-directory: passwords/api
+        run: cargo build
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: passwords/app/package-lock.json
+
+      - name: Install JS dependencies
+        working-directory: passwords/app
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: passwords/app
+        run: npx playwright install chromium --with-deps
+
+      - name: Run e2e tests
+        working-directory: passwords/app
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: passwords/app/playwright-report/
+          retention-days: 7

--- a/.github/workflows/_js-tests.yml
+++ b/.github/workflows/_js-tests.yml
@@ -1,0 +1,27 @@
+name: JS Tests
+
+on:
+  workflow_call:
+
+jobs:
+  js-tests:
+    name: JS Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: passwords/app
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: passwords/app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -1,0 +1,42 @@
+name: Rust Tests
+
+on:
+  workflow_call:
+
+jobs:
+  rust-tests:
+    name: Rust Tests
+    runs-on: ubuntu-latest
+    env:
+      MONGO_USER: ${{ secrets.MONGO_USER }}
+      MONGO_PW: ${{ secrets.MONGO_PW }}
+      MONGO_ENDPOINT: ${{ secrets.MONGO_ENDPOINT }}
+      USERS_DB_NAME: ${{ secrets.USERS_DB_NAME }}
+      FRONTEND_ORIGIN: http://localhost:3000
+    defaults:
+      run:
+        working-directory: passwords/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            passwords/api/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('passwords/api/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run unit tests
+        run: cargo test --lib
+
+      - name: Run integration tests
+        run: cargo test --test integration_tests --features test-helpers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,126 +2,23 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master, passwords/master]
+    branches: [main]
     paths:
       - "passwords/**"
   push:
-    branches: [main, master, passwords/master]
+    branches: [main]
     paths:
       - "passwords/**"
 
 jobs:
   rust-tests:
-    name: Rust Tests
-    runs-on: ubuntu-latest
-    env:
-      MONGO_USER: ${{ secrets.MONGO_USER }}
-      MONGO_PW: ${{ secrets.MONGO_PW }}
-      MONGO_ENDPOINT: ${{ secrets.MONGO_ENDPOINT }}
-      USERS_DB_NAME: ${{ secrets.USERS_DB_NAME }}
-      FRONTEND_ORIGIN: http://localhost:3000
-    defaults:
-      run:
-        working-directory: passwords/api
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry & build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            passwords/api/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('passwords/api/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
-
-      - name: Run unit tests
-        run: cargo test --lib
-
-      - name: Run integration tests
-        run: cargo test --test integration_tests --features test-helpers
+    uses: ./.github/workflows/_rust-tests.yml
+    secrets: inherit
 
   js-tests:
-    name: JS Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: passwords/app
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: npm
-          cache-dependency-path: passwords/app/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests
-        run: npm run test:unit
+    uses: ./.github/workflows/_js-tests.yml
+    secrets: inherit
 
   e2e-tests:
-    name: E2E Tests (Playwright)
-    runs-on: ubuntu-latest
-    env:
-      MONGO_USER: ${{ secrets.MONGO_USER }}
-      MONGO_PW: ${{ secrets.MONGO_PW }}
-      MONGO_ENDPOINT: ${{ secrets.MONGO_ENDPOINT }}
-      USERS_DB_NAME: ${{ secrets.USERS_DB_NAME }}
-      FRONTEND_ORIGIN: http://localhost:3000
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry & build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            passwords/api/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('passwords/api/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Build API (debug)
-        working-directory: passwords/api
-        run: cargo build
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: npm
-          cache-dependency-path: passwords/app/package-lock.json
-
-      - name: Install JS dependencies
-        working-directory: passwords/app
-        run: npm ci
-
-      - name: Install Playwright Chromium
-        working-directory: passwords/app
-        run: npx playwright install chromium --with-deps
-
-      - name: Run e2e tests
-        working-directory: passwords/app
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: passwords/app/playwright-report/
-          retention-days: 7
+    uses: ./.github/workflows/_e2e-tests.yml
+    secrets: inherit

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,24 @@
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "passwords/api/**"
+
+jobs:
+  deploy:
+    name: Deploy API to Fly.io
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: passwords/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -7,8 +7,21 @@ on:
       - "passwords/api/**"
 
 jobs:
+  rust-tests:
+    uses: ./.github/workflows/_rust-tests.yml
+    secrets: inherit
+
+  js-tests:
+    uses: ./.github/workflows/_js-tests.yml
+    secrets: inherit
+
+  e2e-tests:
+    uses: ./.github/workflows/_e2e-tests.yml
+    secrets: inherit
+
   deploy:
     name: Deploy API to Fly.io
+    needs: [rust-tests, js-tests, e2e-tests]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Extracts the 3 CI test jobs (rust-tests, js-tests, e2e-tests) into reusable callable workflows (`_rust-tests.yml`, `_js-tests.yml`, `_e2e-tests.yml`)
- Refactors `ci.yml` to call these reusable workflows instead of inlining the jobs
- Updates `deploy-api.yml` to run all 3 test suites before deploying — the deploy job now `needs: [rust-tests, js-tests, e2e-tests]`

Supersedes #50 — this branch is based on #50's branch and adds the test validation gate.

## Test plan
- [ ] Verify CI workflow still triggers correctly on PRs to `main`
- [ ] Verify deploy workflow runs tests before deploying when `passwords/api/**` changes on `main`
- [ ] Confirm deploy is skipped if any test suite fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)