### PR TITLE
Ping backend on app load to reduce cold start latency

### DIFF
--- a/passwords/app/src/App.js
+++ b/passwords/app/src/App.js
@@ -18,6 +18,11 @@ export default function App() {
 
   const backend = process.env.REACT_APP_BACKEND_URL || "http://localhost:8000";
 
+  // Fire-and-forget ping to wake up the backend server (Fly.io cold start).
+  useEffect(() => {
+    fetch(`${backend}/`).catch(() => {});
+  }, [backend]);
+
   const setAccountInfo = (user, en_user, derivedAesKey, en_pw) => {
     setUsername(user);
     setEnUser(en_user);

--- a/passwords/app/src/App.js
+++ b/passwords/app/src/App.js
@@ -18,7 +18,7 @@ export default function App() {
 
   const backend = process.env.REACT_APP_BACKEND_URL || "http://localhost:8000";
 
-  // Fire-and-forget ping to wake up the backend server (Fly.io cold start).
+  // Fire-and-forget ping to wake up the backend server (cold start).
   useEffect(() => {
     fetch(`${backend}/`).catch(() => {});
   }, [backend]);

--- a/passwords/app/src/App.test.js
+++ b/passwords/app/src/App.test.js
@@ -1,6 +1,51 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import App from './App';
+
+// Mock the loader module — it manipulates the DOM directly (querySelector)
+// which doesn't exist in the test environment.
+jest.mock("./loader/loader", () => ({
+  showLoader: jest.fn(),
+  hideLoader: jest.fn(),
+}));
 
 test('App module exports a component', () => {
   expect(typeof App).toBe('function');
+});
+
+describe("backend wake-up ping on mount", () => {
+  let originalConsoleError;
+
+  beforeEach(() => {
+    originalConsoleError = console.error;
+    console.error = jest.fn();
+    global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+    jest.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  test("fires a GET request to the backend root on mount", async () => {
+    await act(async () => {
+      render(<App />);
+    });
+
+    const pingCall = global.fetch.mock.calls.find(
+      (call) => call[0] === "http://localhost:8000/"
+    );
+    expect(pingCall).toBeDefined();
+  });
+
+  test("ping silently ignores network errors", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down")));
+
+    // Should not throw.
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("http://localhost:8000/");
+  });
 });


### PR DESCRIPTION
## Summary
- Fires a fire-and-forget `GET /` to the backend on app mount, so the Fly.io server starts waking up while the user enters credentials
- Backend already has a `GET /` handler — no API changes needed
- Added 2 unit tests for the ping behavior

Closes #51

## Test plan
- [x] JS unit tests pass (23 tests, 3 suites)
- [x] Rust unit tests pass (32 tests)
- [ ] Manual: load the app, confirm network tab shows a `GET /` request immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)