### PR TITLE
Add backwards compatibility tests and fix concurrent mutation data loss

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -39,7 +39,11 @@ jobs:
         run: cargo test --lib
 
       - name: Run integration tests
-        run: cargo test --tests --features test-helpers -- --skip backcompat
+        run: cargo test --tests --features test-helpers -- --skip backcompat --skip concurrency
+
+      - name: Run concurrency tests (10x for flake detection)
+        shell: bash
+        run: for i in $(seq 1 10); do cargo test --test concurrency_tests --features test-helpers; done
 
       - name: Run backwards compatibility tests
         run: cargo test --test backcompat_tests --features test-helpers

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --test integration_tests --features test-helpers
+
+      - name: Run backwards compatibility tests
+        run: cargo test --test backcompat_tests --features test-helpers

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -41,5 +41,11 @@ jobs:
       - name: Run integration tests
         run: cargo test --test integration_tests --features test-helpers
 
+      - name: Run concurrency tests
+        run: cargo test --test concurrency_tests --features test-helpers
+
+      - name: Run metrics tests
+        run: cargo test --test metrics_tests --features test-helpers
+
       - name: Run backwards compatibility tests
         run: cargo test --test backcompat_tests --features test-helpers

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -39,13 +39,7 @@ jobs:
         run: cargo test --lib
 
       - name: Run integration tests
-        run: cargo test --test integration_tests --features test-helpers
-
-      - name: Run concurrency tests
-        run: cargo test --test concurrency_tests --features test-helpers
-
-      - name: Run metrics tests
-        run: cargo test --test metrics_tests --features test-helpers
+        run: cargo test --tests --features test-helpers -- --skip backcompat
 
       - name: Run backwards compatibility tests
         run: cargo test --test backcompat_tests --features test-helpers

--- a/passwords/api/src/db.rs
+++ b/passwords/api/src/db.rs
@@ -272,11 +272,11 @@ pub async fn change_master_password(
         });
     }
 
-    if user.stored_passwords.len() != updated_stored_passwords.len() {
+    if current_user.stored_passwords.len() != updated_stored_passwords.len() {
         return Err(DbError::GenericError {
             error_msg: format!(
                 "Expected {} updated passwords, found {}",
-                user.stored_passwords.len(),
+                current_user.stored_passwords.len(),
                 updated_stored_passwords.len()
             ),
         });
@@ -291,7 +291,7 @@ pub async fn change_master_password(
         doc! {
             "$set": {
                 "master_key": Bson::from(new_mk),
-                "stored_passwords": user.stored_passwords
+                "stored_passwords": current_user.stored_passwords
                     .into_iter()
                     .zip(updated_stored_passwords.into_iter())
                     .map(|(kv, en_password)| PasswordKV { key: kv.key, en_password })

--- a/passwords/api/src/db.rs
+++ b/passwords/api/src/db.rs
@@ -535,7 +535,7 @@ mod tests {
     // Test the duplicate key detection logic used in add_stored_password
     #[test]
     fn test_duplicate_key_detection() {
-        let passwords = vec![
+        let passwords = [
             PasswordKV {
                 key: "gmail".to_string(),
                 en_password: "enc1".to_string(),

--- a/passwords/api/tests/backcompat_setup.rs
+++ b/passwords/api/tests/backcompat_setup.rs
@@ -13,7 +13,7 @@
 mod common;
 
 use axum::body::Body;
-use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, OLD_RAW_USER, EXPECTED_PASSWORDS};
+use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, EXPECTED_PASSWORDS};
 use common::{app, body_string, run, WithAuth};
 use http::{Request, StatusCode};
 use tower::ServiceExt;
@@ -22,21 +22,6 @@ use tower::ServiceExt;
 #[ignore]
 fn setup_backcompat_user() {
     run(async {
-        // 0. Clean up the old broken user that was created with the raw
-        //    (unhashed) username. Ignore errors — the user may not exist.
-        let req = Request::builder()
-            .method("DELETE")
-            .uri("/api/v2/user")
-            .header("x-username", OLD_RAW_USER)
-            .header("x-password", "unused")
-            .body(Body::empty())
-            .unwrap();
-        let res = app().oneshot(req).await.unwrap();
-        eprintln!(
-            "Old user cleanup: status {}",
-            res.status()
-        );
-
         // 1. Create the user with hashed credentials (as the frontend would
         //    send after `encryptMaster()`). If it already exists the API
         //    returns 404 (uniform error responses), which we treat as success.

--- a/passwords/api/tests/backcompat_setup.rs
+++ b/passwords/api/tests/backcompat_setup.rs
@@ -13,7 +13,7 @@
 mod common;
 
 use axum::body::Body;
-use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, EXPECTED_PASSWORDS};
+use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, OLD_RAW_USER, EXPECTED_PASSWORDS};
 use common::{app, body_string, run, WithAuth};
 use http::{Request, StatusCode};
 use tower::ServiceExt;
@@ -22,8 +22,24 @@ use tower::ServiceExt;
 #[ignore]
 fn setup_backcompat_user() {
     run(async {
-        // 1. Create the user. If it already exists the API returns 404
-        //    (uniform error responses), which we treat as success.
+        // 0. Clean up the old broken user that was created with the raw
+        //    (unhashed) username. Ignore errors — the user may not exist.
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/api/v2/user")
+            .header("x-username", OLD_RAW_USER)
+            .header("x-password", "unused")
+            .body(Body::empty())
+            .unwrap();
+        let res = app().oneshot(req).await.unwrap();
+        eprintln!(
+            "Old user cleanup: status {}",
+            res.status()
+        );
+
+        // 1. Create the user with hashed credentials (as the frontend would
+        //    send after `encryptMaster()`). If it already exists the API
+        //    returns 404 (uniform error responses), which we treat as success.
         let req = Request::builder()
             .method("POST")
             .uri("/api/v2/user")
@@ -55,8 +71,10 @@ fn setup_backcompat_user() {
             "backcompat user must be verifiable after creation"
         );
 
-        // 3. Add stored passwords. If a key already exists the API returns
-        //    404 (duplicate key → uniform error), which we skip gracefully.
+        // 3. Add stored passwords with AES-encrypted values (encrypted with
+        //    SHA-256 of the plaintext password as key). If a key already
+        //    exists the API returns 404 (duplicate key → uniform error),
+        //    which we skip gracefully.
         for (key, enc_pw) in EXPECTED_PASSWORDS {
             let req = Request::builder()
                 .method("POST")

--- a/passwords/api/tests/backcompat_setup.rs
+++ b/passwords/api/tests/backcompat_setup.rs
@@ -1,0 +1,96 @@
+//! One-time setup for the backwards-compatibility test user.
+//!
+//! This test is `#[ignore]`d so it only runs when explicitly requested:
+//!
+//! ```sh
+//! cargo test --test backcompat_setup -- --ignored --features test-helpers
+//! ```
+//!
+//! It creates a permanent user with known credentials and stored passwords.
+//! If the user already exists (duplicate → 404 under uniform error policy),
+//! the test succeeds gracefully.
+
+mod common;
+
+use axum::body::Body;
+use common::{app, body_string, run, WithAuth};
+use http::{Request, StatusCode};
+use tower::ServiceExt;
+
+// Hardcoded credentials for the backcompat user.
+const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
+const BACKCOMPAT_PW: &str = "backcompat_password_123";
+
+// Stored passwords to seed.
+const STORED_PASSWORDS: &[(&str, &str)] = &[
+    ("email", "enc_email_value"),
+    ("bank", "enc_bank_value"),
+    ("social", "enc_social_value"),
+];
+
+#[test]
+#[ignore]
+fn setup_backcompat_user() {
+    run(async {
+        // 1. Create the user. If it already exists the API returns 404
+        //    (uniform error responses), which we treat as success.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v2/user")
+            .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+            .body(Body::empty())
+            .unwrap();
+        let res = app().oneshot(req).await.unwrap();
+        let status = res.status();
+        let body = body_string(res).await;
+        match status {
+            StatusCode::OK => eprintln!("Created backcompat user"),
+            StatusCode::NOT_FOUND => {
+                eprintln!("Backcompat user already exists (got 404): {body}");
+            }
+            other => panic!("Unexpected status {other} creating backcompat user: {body}"),
+        }
+
+        // 2. Verify we can authenticate as the backcompat user.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/v2/user/verify")
+            .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+            .body(Body::empty())
+            .unwrap();
+        let res = app().oneshot(req).await.unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::OK,
+            "backcompat user must be verifiable after creation"
+        );
+
+        // 3. Add stored passwords. If a key already exists the API returns
+        //    404 (duplicate key → uniform error), which we skip gracefully.
+        for (key, enc_pw) in STORED_PASSWORDS {
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!("/api/v2/passwords/{key}"))
+                .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"encrypted_password":"{enc_pw}"}}"#
+                )))
+                .unwrap();
+            let res = app().oneshot(req).await.unwrap();
+            let status = res.status();
+            match status {
+                StatusCode::OK => eprintln!("Added key '{key}'"),
+                StatusCode::NOT_FOUND => {
+                    eprintln!("Key '{key}' already exists (got 404), skipping");
+                }
+                other => {
+                    let body = body_string(res).await;
+                    panic!("Unexpected status {other} adding key '{key}': {body}");
+                }
+            }
+        }
+
+        eprintln!("Backcompat setup complete.");
+    });
+}

--- a/passwords/api/tests/backcompat_setup.rs
+++ b/passwords/api/tests/backcompat_setup.rs
@@ -13,20 +13,10 @@
 mod common;
 
 use axum::body::Body;
+use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, EXPECTED_PASSWORDS};
 use common::{app, body_string, run, WithAuth};
 use http::{Request, StatusCode};
 use tower::ServiceExt;
-
-// Hardcoded credentials for the backcompat user.
-const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
-const BACKCOMPAT_PW: &str = "backcompat_password_123";
-
-// Stored passwords to seed.
-const STORED_PASSWORDS: &[(&str, &str)] = &[
-    ("email", "enc_email_value"),
-    ("bank", "enc_bank_value"),
-    ("social", "enc_social_value"),
-];
 
 #[test]
 #[ignore]
@@ -67,7 +57,7 @@ fn setup_backcompat_user() {
 
         // 3. Add stored passwords. If a key already exists the API returns
         //    404 (duplicate key → uniform error), which we skip gracefully.
-        for (key, enc_pw) in STORED_PASSWORDS {
+        for (key, enc_pw) in EXPECTED_PASSWORDS {
             let req = Request::builder()
                 .method("POST")
                 .uri(format!("/api/v2/passwords/{key}"))

--- a/passwords/api/tests/backcompat_tests.rs
+++ b/passwords/api/tests/backcompat_tests.rs
@@ -1,0 +1,107 @@
+//! Backwards-compatibility tests for the permanent backcompat test user.
+//!
+//! These tests verify that a user created by `backcompat_setup.rs` can still
+//! authenticate and retrieve their stored passwords. This guards against
+//! breaking changes to auth, encryption, or data format.
+//!
+//! ## Prerequisites
+//!
+//! Run the setup once before these tests:
+//!
+//! ```sh
+//! cargo test --test backcompat_setup -- --ignored --features test-helpers
+//! ```
+//!
+//! ## Running
+//!
+//! ```sh
+//! cargo test --test backcompat_tests --features test-helpers
+//! ```
+
+mod common;
+
+use axum::body::Body;
+use common::{app, body_string, parse_json, run, WithAuth};
+use http::{Request, StatusCode};
+use tower::ServiceExt;
+
+// ── Expected values (must match backcompat_setup.rs) ────────────────────────
+
+const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
+const BACKCOMPAT_PW: &str = "backcompat_password_123";
+
+const EXPECTED_KEYS: &[&str] = &["email", "bank", "social"];
+
+const EXPECTED_PASSWORDS: &[(&str, &str)] = &[
+    ("email", "enc_email_value"),
+    ("bank", "enc_bank_value"),
+    ("social", "enc_social_value"),
+];
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_backcompat_user_can_authenticate() {
+    run(async {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/v2/user/verify")
+            .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+            .body(Body::empty())
+            .unwrap();
+        let res = app().oneshot(req).await.unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::OK,
+            "backcompat user should authenticate with known credentials"
+        );
+    });
+}
+
+#[test]
+fn test_backcompat_user_keys_exist() {
+    run(async {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/v2/keys")
+            .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+            .body(Body::empty())
+            .unwrap();
+        let res = app().oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let keys: Vec<String> = parse_json(&body_string(res).await);
+        for expected_key in EXPECTED_KEYS {
+            assert!(
+                keys.contains(&(*expected_key).to_string()),
+                "expected key '{expected_key}' not found in keys: {keys:?}"
+            );
+        }
+    });
+}
+
+#[test]
+fn test_backcompat_user_passwords_retrievable() {
+    run(async {
+        for (key, expected_value) in EXPECTED_PASSWORDS {
+            let req = Request::builder()
+                .method("GET")
+                .uri(format!("/api/v2/passwords/{key}"))
+                .auth(BACKCOMPAT_USER, BACKCOMPAT_PW)
+                .body(Body::empty())
+                .unwrap();
+            let res = app().oneshot(req).await.unwrap();
+            assert_eq!(
+                res.status(),
+                StatusCode::OK,
+                "GET /passwords/{key} should succeed"
+            );
+
+            let value: String = parse_json(&body_string(res).await);
+            assert_eq!(
+                value, *expected_value,
+                "password for key '{key}' does not match expected value"
+            );
+        }
+    });
+}

--- a/passwords/api/tests/backcompat_tests.rs
+++ b/passwords/api/tests/backcompat_tests.rs
@@ -21,22 +21,10 @@
 mod common;
 
 use axum::body::Body;
+use common::backcompat::{BACKCOMPAT_PW, BACKCOMPAT_USER, EXPECTED_KEYS, EXPECTED_PASSWORDS};
 use common::{app, body_string, parse_json, run, WithAuth};
 use http::{Request, StatusCode};
 use tower::ServiceExt;
-
-// ── Expected values (must match backcompat_setup.rs) ────────────────────────
-
-const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
-const BACKCOMPAT_PW: &str = "backcompat_password_123";
-
-const EXPECTED_KEYS: &[&str] = &["email", "bank", "social"];
-
-const EXPECTED_PASSWORDS: &[(&str, &str)] = &[
-    ("email", "enc_email_value"),
-    ("bank", "enc_bank_value"),
-    ("social", "enc_social_value"),
-];
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 

--- a/passwords/api/tests/backcompat_tests.rs
+++ b/passwords/api/tests/backcompat_tests.rs
@@ -1,22 +1,4 @@
 //! Backwards-compatibility tests for the permanent backcompat test user.
-//!
-//! These tests verify that a user created by `backcompat_setup.rs` can still
-//! authenticate and retrieve their stored passwords. This guards against
-//! breaking changes to auth, encryption, or data format.
-//!
-//! ## Prerequisites
-//!
-//! Run the setup once before these tests:
-//!
-//! ```sh
-//! cargo test --test backcompat_setup -- --ignored --features test-helpers
-//! ```
-//!
-//! ## Running
-//!
-//! ```sh
-//! cargo test --test backcompat_tests --features test-helpers
-//! ```
 
 mod common;
 

--- a/passwords/api/tests/common.rs
+++ b/passwords/api/tests/common.rs
@@ -22,15 +22,26 @@ pub const TEST_PW: &str = "test_password_abc123";
 // Shared between backcompat_setup.rs and backcompat_tests.rs.
 
 pub mod backcompat {
-    pub const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
-    pub const BACKCOMPAT_PW: &str = "backcompat_password_123";
+    /// Plaintext credentials — used by e2e tests that log in through the UI.
+    pub const BACKCOMPAT_PLAINTEXT_USER: &str = "backcompat_test_user";
+    pub const BACKCOMPAT_PLAINTEXT_PW: &str = "backcompat_password_123";
+
+    /// Client-side SHA-3 hashed credentials (output of `encryptMaster()`).
+    /// These are what the frontend sends as `x-username` / `x-password` headers.
+    pub const BACKCOMPAT_USER: &str = "93aba7f07aa6cd38";
+    pub const BACKCOMPAT_PW: &str = "e6c146a2e22f5e2e";
+
+    /// The old raw username used by the previous (broken) backcompat user.
+    /// Used only for cleanup in `backcompat_setup.rs`.
+    pub const OLD_RAW_USER: &str = "__backcompat_test_user__";
 
     pub const EXPECTED_KEYS: &[&str] = &["email", "bank", "social"];
 
+    /// Encrypted password values (AES with SHA-256 of the plaintext password as key).
     pub const EXPECTED_PASSWORDS: &[(&str, &str)] = &[
-        ("email", "enc_email_value"),
-        ("bank", "enc_bank_value"),
-        ("social", "enc_social_value"),
+        ("email", "U2FsdGVkX184eJIaOi3wqeiw22+VTItwS6ujyQjQl6yr6kSW9UKrtq5sFLoCe7aD"),
+        ("bank", "U2FsdGVkX19Szi+RIYAHWUjHPgLM3EKL43CrEJB8zyfb2GY6u+Pn4dw/3uSMeZQk"),
+        ("social", "U2FsdGVkX1/0UvpMeilf4CXaAppupUSgA6di9fjBv26F1pdUyPLJiJmQTMdx6n4K"),
     ];
 }
 

--- a/passwords/api/tests/common.rs
+++ b/passwords/api/tests/common.rs
@@ -3,6 +3,10 @@
 //! Provides a shared tokio runtime, Axum router, RAII test user cleanup,
 //! and common helpers. Import via `mod common;` from any test file.
 
+// Each test binary compiles this module independently and may not use every
+// item. Suppress dead-code warnings that arise from partial usage.
+#![allow(dead_code)]
+
 use axum::body::Body;
 use axum::{Router, middleware::from_fn, extract::ConnectInfo};
 use http::Request;
@@ -71,6 +75,12 @@ impl WithAuth for http::request::Builder {
 pub struct TestUser {
     username: String,
     password: String,
+}
+
+impl Default for TestUser {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TestUser {

--- a/passwords/api/tests/common.rs
+++ b/passwords/api/tests/common.rs
@@ -3,10 +3,6 @@
 //! Provides a shared tokio runtime, Axum router, RAII test user cleanup,
 //! and common helpers. Import via `mod common;` from any test file.
 
-// Each test binary compiles this module independently and may not use every
-// item. Suppress dead-code warnings that arise from partial usage.
-#![allow(dead_code)]
-
 use axum::body::Body;
 use axum::{Router, middleware::from_fn, extract::ConnectInfo};
 use http::Request;
@@ -21,19 +17,12 @@ pub const TEST_PW: &str = "test_password_abc123";
 // ── Backcompat test constants ──────────────────────────────────────────────
 // Shared between backcompat_setup.rs and backcompat_tests.rs.
 
+#[allow(dead_code)]
 pub mod backcompat {
-    /// Plaintext credentials — used by e2e tests that log in through the UI.
-    pub const BACKCOMPAT_PLAINTEXT_USER: &str = "backcompat_test_user";
-    pub const BACKCOMPAT_PLAINTEXT_PW: &str = "backcompat_password_123";
-
     /// Client-side SHA-3 hashed credentials (output of `encryptMaster()`).
     /// These are what the frontend sends as `x-username` / `x-password` headers.
     pub const BACKCOMPAT_USER: &str = "93aba7f07aa6cd38";
     pub const BACKCOMPAT_PW: &str = "e6c146a2e22f5e2e";
-
-    /// The old raw username used by the previous (broken) backcompat user.
-    /// Used only for cleanup in `backcompat_setup.rs`.
-    pub const OLD_RAW_USER: &str = "__backcompat_test_user__";
 
     pub const EXPECTED_KEYS: &[&str] = &["email", "bank", "social"];
 

--- a/passwords/api/tests/common.rs
+++ b/passwords/api/tests/common.rs
@@ -18,6 +18,22 @@ use std::sync::LazyLock;
 
 pub const TEST_PW: &str = "test_password_abc123";
 
+// ── Backcompat test constants ──────────────────────────────────────────────
+// Shared between backcompat_setup.rs and backcompat_tests.rs.
+
+pub mod backcompat {
+    pub const BACKCOMPAT_USER: &str = "__backcompat_test_user__";
+    pub const BACKCOMPAT_PW: &str = "backcompat_password_123";
+
+    pub const EXPECTED_KEYS: &[&str] = &["email", "bank", "social"];
+
+    pub const EXPECTED_PASSWORDS: &[(&str, &str)] = &[
+        ("email", "enc_email_value"),
+        ("bank", "enc_bank_value"),
+        ("social", "enc_social_value"),
+    ];
+}
+
 // ---------------------------------------------------------------------------
 // Single shared runtime – keeps the MongoDB connection pool alive across tests.
 // Shared Axum router + DB connection (initialized once on the shared runtime).

--- a/passwords/app/e2e/passwords.spec.js
+++ b/passwords/app/e2e/passwords.spec.js
@@ -466,6 +466,68 @@ test.describe.serial("Full user journey", () => {
   });
 });
 
+// ── Backwards-compatibility tests ───────────────────────────────────────────
+//
+// These tests verify that the permanent backcompat test user (created by the
+// Rust `backcompat_setup` test) can still authenticate and retrieve its stored
+// passwords. Because the user was created via the API with raw header values
+// (not through the UI's SHA-3 hashing), we make direct API requests here
+// rather than driving the UI.
+
+const BACKCOMPAT_USER = "__backcompat_test_user__";
+const BACKCOMPAT_PW = "backcompat_password_123";
+const BACKCOMPAT_EXPECTED_KEYS = ["email", "bank", "social"];
+
+test.describe("Backwards compatibility", () => {
+  test("backcompat user can authenticate and keys are present", async ({
+    request,
+  }) => {
+    // Verify the user can authenticate.
+    const verifyRes = await request.get(`${API}/api/v2/user/verify`, {
+      headers: {
+        "x-username": BACKCOMPAT_USER,
+        "x-password": BACKCOMPAT_PW,
+      },
+    });
+    expect(verifyRes.ok()).toBeTruthy();
+
+    // Verify all expected keys are present.
+    const keysRes = await request.get(`${API}/api/v2/keys`, {
+      headers: {
+        "x-username": BACKCOMPAT_USER,
+        "x-password": BACKCOMPAT_PW,
+      },
+    });
+    expect(keysRes.ok()).toBeTruthy();
+
+    const keys = await keysRes.json();
+    for (const expectedKey of BACKCOMPAT_EXPECTED_KEYS) {
+      expect(keys).toContain(expectedKey);
+    }
+  });
+
+  test("backcompat user passwords are retrievable", async ({ request }) => {
+    const expectedPasswords = [
+      { key: "email", value: "enc_email_value" },
+      { key: "bank", value: "enc_bank_value" },
+      { key: "social", value: "enc_social_value" },
+    ];
+
+    for (const { key, value } of expectedPasswords) {
+      const res = await request.get(`${API}/api/v2/passwords/${key}`, {
+        headers: {
+          "x-username": BACKCOMPAT_USER,
+          "x-password": BACKCOMPAT_PW,
+        },
+      });
+      expect(res.ok()).toBeTruthy();
+
+      const body = await res.json();
+      expect(body).toBe(value);
+    }
+  });
+});
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**

--- a/passwords/app/e2e/passwords.spec.js
+++ b/passwords/app/e2e/passwords.spec.js
@@ -476,7 +476,11 @@ test.describe.serial("Full user journey", () => {
 
 const BACKCOMPAT_PLAINTEXT_USER = "backcompat_test_user";
 const BACKCOMPAT_PLAINTEXT_PW = "backcompat_password_123";
-const BACKCOMPAT_EXPECTED_KEYS = ["email", "bank", "social"];
+const BACKCOMPAT_EXPECTED_PASSWORDS = {
+  email: "my_email_password",
+  bank: "my_bank_password",
+  social: "my_social_password",
+};
 
 test.describe.serial("Backwards compatibility", () => {
   /** @type {import('@playwright/test').Page} */
@@ -507,51 +511,11 @@ test.describe.serial("Backwards compatibility", () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test("backcompat user keys are present in dropdown", async () => {
-    // Open the autocomplete dropdown to see all available keys.
-    const autocomplete = page.getByRole("combobox", {
-      name: "Select a password key",
-    });
-    await autocomplete.click();
-
-    // Verify each expected key appears as an option.
-    for (const expectedKey of BACKCOMPAT_EXPECTED_KEYS) {
-      await expect(
-        page.getByRole("option", { name: expectedKey })
-      ).toBeVisible({ timeout: 5_000 });
-    }
-
-    // Close the dropdown by pressing Escape.
-    await page.keyboard.press("Escape");
-  });
-
-  test("backcompat user passwords decrypt correctly through the UI", async () => {
-    // Grant clipboard permissions for reading the decrypted value.
-    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-
-    for (const key of BACKCOMPAT_EXPECTED_KEYS) {
-      const autocomplete = page.getByRole("combobox", {
-        name: "Select a password key",
-      });
-      await autocomplete.click();
-      await autocomplete.fill("");
-      await autocomplete.fill(key);
-      await page.getByRole("option", { name: key }).click();
-
-      // Wait for the "Retrieved password for <key>!" alert — this only
-      // appears when client-side AES decryption succeeds.
-      await expect(
-        page.getByText(`Retrieved password for ${key}!`)
-      ).toBeVisible({ timeout: 10_000 });
-
-      // Click to copy the decrypted password to clipboard.
-      await page.getByText("Click here to copy.").click();
-
-      // Read the clipboard and verify it contains a non-empty decrypted value.
-      const clipboardText = await page.evaluate(() =>
-        navigator.clipboard.readText()
-      );
-      expect(clipboardText.length).toBeGreaterThan(0);
+  test("backcompat user passwords decrypt to expected plaintext values", async () => {
+    // Select each key from the dropdown, retrieve the password, and verify
+    // the decrypted value matches the expected plaintext.
+    for (const [key, expectedPlaintext] of Object.entries(BACKCOMPAT_EXPECTED_PASSWORDS)) {
+      await queryAndVerifyPassword(page, key, expectedPlaintext);
     }
   });
 });

--- a/passwords/app/e2e/passwords.spec.js
+++ b/passwords/app/e2e/passwords.spec.js
@@ -469,61 +469,89 @@ test.describe.serial("Full user journey", () => {
 // ── Backwards-compatibility tests ───────────────────────────────────────────
 //
 // These tests verify that the permanent backcompat test user (created by the
-// Rust `backcompat_setup` test) can still authenticate and retrieve its stored
-// passwords. Because the user was created via the API with raw header values
-// (not through the UI's SHA-3 hashing), we make direct API requests here
-// rather than driving the UI.
+// Rust `backcompat_setup` test) can still log in through the real UI and
+// retrieve its stored passwords. The user was created with client-side hashed
+// credentials (SHA-3 via encryptMaster), so logging in with the plaintext
+// credentials exercises the full frontend crypto pipeline.
 
-const BACKCOMPAT_USER = "__backcompat_test_user__";
-const BACKCOMPAT_PW = "backcompat_password_123";
+const BACKCOMPAT_PLAINTEXT_USER = "backcompat_test_user";
+const BACKCOMPAT_PLAINTEXT_PW = "backcompat_password_123";
 const BACKCOMPAT_EXPECTED_KEYS = ["email", "bank", "social"];
 
-test.describe("Backwards compatibility", () => {
-  test("backcompat user can authenticate and keys are present", async ({
-    request,
-  }) => {
-    // Verify the user can authenticate.
-    const verifyRes = await request.get(`${API}/api/v2/user/verify`, {
-      headers: {
-        "x-username": BACKCOMPAT_USER,
-        "x-password": BACKCOMPAT_PW,
-      },
-    });
-    expect(verifyRes.ok()).toBeTruthy();
+test.describe.serial("Backwards compatibility", () => {
+  /** @type {import('@playwright/test').Page} */
+  let page;
 
-    // Verify all expected keys are present.
-    const keysRes = await request.get(`${API}/api/v2/keys`, {
-      headers: {
-        "x-username": BACKCOMPAT_USER,
-        "x-password": BACKCOMPAT_PW,
-      },
-    });
-    expect(keysRes.ok()).toBeTruthy();
-
-    const keys = await keysRes.json();
-    for (const expectedKey of BACKCOMPAT_EXPECTED_KEYS) {
-      expect(keys).toContain(expectedKey);
-    }
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
   });
 
-  test("backcompat user passwords are retrievable", async ({ request }) => {
-    const expectedPasswords = [
-      { key: "email", value: "enc_email_value" },
-      { key: "bank", value: "enc_bank_value" },
-      { key: "social", value: "enc_social_value" },
-    ];
+  test.afterAll(async () => {
+    await page.close();
+  });
 
-    for (const { key, value } of expectedPasswords) {
-      const res = await request.get(`${API}/api/v2/passwords/${key}`, {
-        headers: {
-          "x-username": BACKCOMPAT_USER,
-          "x-password": BACKCOMPAT_PW,
-        },
+  test("backcompat user can log in through the UI", async () => {
+    await page.goto("/");
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+
+    // Fill in the plaintext credentials — the frontend hashes them via
+    // encryptMaster() before sending to the API.
+    await page.getByLabel("username").fill(BACKCOMPAT_PLAINTEXT_USER);
+    await page.getByLabel("password").fill(BACKCOMPAT_PLAINTEXT_PW);
+
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    // Wait for the account view to load.
+    await expect(
+      page.getByText("Select a password to retrieve:")
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("backcompat user keys are present in dropdown", async () => {
+    // Open the autocomplete dropdown to see all available keys.
+    const autocomplete = page.getByRole("combobox", {
+      name: "Select a password key",
+    });
+    await autocomplete.click();
+
+    // Verify each expected key appears as an option.
+    for (const expectedKey of BACKCOMPAT_EXPECTED_KEYS) {
+      await expect(
+        page.getByRole("option", { name: expectedKey })
+      ).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Close the dropdown by pressing Escape.
+    await page.keyboard.press("Escape");
+  });
+
+  test("backcompat user passwords decrypt correctly through the UI", async () => {
+    // Grant clipboard permissions for reading the decrypted value.
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    for (const key of BACKCOMPAT_EXPECTED_KEYS) {
+      const autocomplete = page.getByRole("combobox", {
+        name: "Select a password key",
       });
-      expect(res.ok()).toBeTruthy();
+      await autocomplete.click();
+      await autocomplete.fill("");
+      await autocomplete.fill(key);
+      await page.getByRole("option", { name: key }).click();
 
-      const body = await res.json();
-      expect(body).toBe(value);
+      // Wait for the "Retrieved password for <key>!" alert — this only
+      // appears when client-side AES decryption succeeds.
+      await expect(
+        page.getByText(`Retrieved password for ${key}!`)
+      ).toBeVisible({ timeout: 10_000 });
+
+      // Click to copy the decrypted password to clipboard.
+      await page.getByText("Click here to copy.").click();
+
+      // Read the clipboard and verify it contains a non-empty decrypted value.
+      const clipboardText = await page.evaluate(() =>
+        navigator.clipboard.readText()
+      );
+      expect(clipboardText.length).toBeGreaterThan(0);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Adds a permanent "backcompat" test user with known credentials (created via `backcompat_setup.rs`, run once manually)
- Rust integration tests verify auth, key listing, and password retrieval against the permanent user
- E2E tests log in through the real UI and verify passwords decrypt correctly
- Fixes a data loss bug in `change_master_password`: the stored passwords count check and re-encryption used stale data from before the lock, so a concurrent `add_stored_password` could silently have its password dropped
- CI now runs concurrency tests 10x to catch intermittent races

Closes #56

## Test plan
- [x] Backcompat setup creates user
- [x] 3 backcompat Rust tests pass
- [x] E2E backcompat tests verify login + decryption through UI
- [x] Concurrency tests pass consistently (10x local)
- [x] 19 integration tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)