### PR TITLE
Biometric unlock (Touch ID / Face ID) via WebAuthn PRF

### DIFF
--- a/passwords/app/e2e/biometric.spec.js
+++ b/passwords/app/e2e/biometric.spec.js
@@ -1,0 +1,296 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+/**
+ * Biometric (Touch ID / Face ID) unlock e2e suite.
+ *
+ * Uses Chromium's CDP virtual authenticator — a CTAP2 "internal" (platform)
+ * authenticator with PRF support and user verification always passing — to
+ * stand in for Touch ID:
+ *
+ *   1. Create a new user — the post-login offer appears; decline it.
+ *   2. Enable biometric unlock in Settings (creates the passkey); the
+ *      button flips to a disabled "enabled" state with an X to turn off.
+ *   3. Log out, then sign back in via the "Use …" button — logging out
+ *      must NOT auto-fire the prompt.
+ *   4. Reload the page — auto-unlock signs in with zero clicks.
+ *   5. Change the master password — enrollment must be cleared, and the
+ *      unlock button must be gone after logging out.
+ *   6. Log in and enable via the post-login offer's Enable button.
+ *   7. Turn biometrics off via the X in settings.
+ *   8. Ignore the offer, enable in settings instead — the offer must be
+ *      gone when settings closes.
+ *   9. Delete the test user via the API (cleanup).
+ */
+
+const API = "http://localhost:8000";
+
+/** Generate a random alphanumeric string of the given length. */
+function randomString(len) {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  return Array.from({ length: len }, () =>
+    chars.charAt(Math.floor(Math.random() * chars.length))
+  ).join("");
+}
+
+const ctx = {
+  username: `e2e_bio_${randomString(10)}`,
+  password: `BioPass_${randomString(10)}`, // ≥ 13 chars
+  newPassword: `BioNewPw_${randomString(10)}`, // ≥ 13 chars
+  /** SHA3-hashed username sent by the frontend to the API. Captured at sign-up. */
+  hashedUsername: "",
+};
+
+test.describe.serial("Biometric unlock journey", () => {
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    // Install a virtual platform authenticator with PRF (hmac-secret).
+    const client = await page.context().newCDPSession(page);
+    await client.send("WebAuthn.enable");
+    await client.send("WebAuthn.addVirtualAuthenticator", {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        hasPrf: true,
+        automaticPresenceSimulation: true,
+      },
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (ctx.hashedUsername) {
+      await request.delete(`${API}/api/v3/user`, {
+        headers: {
+          "x-username": ctx.hashedUsername,
+          "x-password": "unused",
+        },
+      });
+    }
+    await page.close();
+  });
+
+  test("create a new user", async () => {
+    await page.goto("/");
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+    await page.locator("text=First time?").locator("span").click();
+    await expect(page.getByRole("button", { name: "Sign up" })).toBeVisible();
+
+    await page.getByLabel("username").fill(ctx.username);
+    await page.getByLabel("password").fill(ctx.password);
+
+    const signupPromise = page.waitForRequest(
+      (req) => req.url().endsWith("/api/v3/user") && req.method() === "POST"
+    );
+    await page.getByRole("button", { name: "Sign up" }).click();
+    const signupRequest = await signupPromise;
+    ctx.hashedUsername = signupRequest.headers()["x-username"];
+
+    await expect(
+      page.getByRole("button", { name: "Add a new account" })
+    ).toBeVisible();
+
+    // The post-login offer appears for un-enrolled users; decline it.
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Not now" }).click();
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).not.toBeVisible();
+  });
+
+  test("enable biometric unlock in settings", async () => {
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Settings").click();
+
+    const enableButton = page.getByRole("button", {
+      name: /^Use (Touch ID|Face ID|biometrics)$/,
+    });
+    await expect(enableButton).toBeVisible();
+    await enableButton.click();
+
+    // The button flips to a disabled "enabled" state with an X to turn off.
+    await expect(
+      page.getByRole("button", {
+        name: /(Touch ID|Face ID|biometrics) enabled/,
+      })
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: /Turn off/ })
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Close settings" }).click();
+  });
+
+  test("log out and unlock with biometrics", async () => {
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Log Out").click();
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+
+    const unlockButton = page.getByRole("button", {
+      name: /Use (Touch ID|Face ID|biometrics)/,
+    });
+    await expect(unlockButton).toBeVisible();
+
+    // Logging out must not auto-fire the prompt (once-per-page-load rule):
+    // with automaticPresenceSimulation on, an auto-fired prompt would sign
+    // us straight back in. Verify we stay signed out.
+    await page.waitForTimeout(1500);
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+
+    await unlockButton.click();
+
+    // Signed in without typing anything.
+    await expect(
+      page.getByRole("button", { name: "Add a new account" })
+    ).toBeVisible();
+    // Enrolled users don't get the post-login offer.
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).not.toBeVisible();
+  });
+
+  test("reloading the page auto-unlocks with zero clicks", async () => {
+    await page.reload();
+    // The virtual authenticator auto-approves, so the auto-fired prompt
+    // signs us in without touching the form.
+    await expect(
+      page.getByRole("button", { name: "Add a new account" })
+    ).toBeVisible();
+  });
+
+  test("changing the master password clears the enrollment", async () => {
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Settings").click();
+
+    // { exact: true } because "New Password" is a substring of
+    // "Confirm New Password".
+    await page.getByLabel("New Password", { exact: true }).fill(ctx.newPassword);
+    await page.getByLabel("Confirm New Password").fill(ctx.newPassword);
+    await page.getByRole("button", { name: "Change Password" }).click();
+
+    await expect(
+      page.getByText(/was turned off/)
+    ).toBeVisible({ timeout: 30_000 });
+    // The biometric button is back to its clickable un-enrolled state.
+    await expect(
+      page.getByRole("button", {
+        name: /^Use (Touch ID|Face ID|biometrics)$/,
+      })
+    ).toBeEnabled();
+    await page.getByRole("button", { name: "Close settings" }).click();
+
+    // After logging out the unlock button must be gone.
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Log Out").click();
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Use (Touch ID|Face ID|biometrics)/ })
+    ).not.toBeVisible();
+
+    // And the new password still works.
+    await page.getByLabel("username").fill(ctx.username);
+    await page.getByLabel("password").fill(ctx.newPassword);
+    await page.getByRole("button", { name: "Log In" }).click();
+    await expect(
+      page.getByRole("button", { name: "Add a new account" })
+    ).toBeVisible();
+  });
+
+  test("enable via the post-login offer", async () => {
+    // The offer was declined in step 1 ("Not now" persists); un-dismiss it
+    // to test the Enable path.
+    await page.evaluate(() =>
+      localStorage.removeItem("mapopass.biometric.promo-dismissed")
+    );
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Log Out").click();
+    await page.getByLabel("username").fill(ctx.username);
+    await page.getByLabel("password").fill(ctx.newPassword);
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Enable" }).click();
+    await expect(
+      page.getByText(/(Touch ID|Face ID|biometrics) turned on/)
+    ).toBeVisible();
+
+    // The enrollment is live: the unlock button is back after logging out.
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Log Out").click();
+    await expect(
+      page.getByRole("button", { name: /Use (Touch ID|Face ID|biometrics)/ })
+    ).toBeVisible();
+  });
+
+  test("turn off via the X in settings", async () => {
+    // Unlock (manual click — the page-load auto-attempt was already spent),
+    // then disable from settings via the X next to the enabled button.
+    await page
+      .getByRole("button", { name: /Use (Touch ID|Face ID|biometrics)/ })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Add a new account" })
+    ).toBeVisible();
+
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Settings").click();
+    await expect(
+      page.getByRole("button", {
+        name: /(Touch ID|Face ID|biometrics) enabled/,
+      })
+    ).toBeDisabled();
+    await page.getByRole("button", { name: /Turn off/ }).click();
+
+    // Back to the clickable un-enrolled state.
+    await expect(
+      page.getByRole("button", {
+        name: /^Use (Touch ID|Face ID|biometrics)$/,
+      })
+    ).toBeEnabled();
+    await page.getByRole("button", { name: "Close settings" }).click();
+
+    // Enrollment is gone: no unlock button after logging out.
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Log Out").click();
+    await expect(page.getByText("Welcome to MapoPass")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Use (Touch ID|Face ID|biometrics)/ })
+    ).not.toBeVisible();
+  });
+
+  test("offer retires itself after enabling in settings", async () => {
+    // Log in un-enrolled and un-dismissed: the offer appears.
+    await page.getByLabel("username").fill(ctx.username);
+    await page.getByLabel("password").fill(ctx.newPassword);
+    await page.getByRole("button", { name: "Log In" }).click();
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).toBeVisible();
+
+    // Ignore it; enable from settings instead.
+    await page.locator(".Account-dropdown .user").click();
+    await page.getByText("Settings").click();
+    await page
+      .getByRole("button", { name: /^Use (Touch ID|Face ID|biometrics)$/ })
+      .click();
+    await expect(
+      page.getByRole("button", {
+        name: /(Touch ID|Face ID|biometrics) enabled/,
+      })
+    ).toBeDisabled();
+    await page.getByRole("button", { name: "Close settings" }).click();
+
+    // The stale offer must not resurface.
+    await expect(
+      page.getByText(/Use (Touch ID|Face ID|biometrics) instead of your password/)
+    ).not.toBeVisible();
+  });
+});

--- a/passwords/app/e2e/passwords.spec.js
+++ b/passwords/app/e2e/passwords.spec.js
@@ -455,8 +455,8 @@ test.describe.serial("Full user journey", () => {
       .fill(ctx.newPassword);
     await page.getByLabel("Confirm New Password").fill(ctx.newPassword);
 
-    // Click Save.
-    await page.getByRole("button", { name: "Save" }).click();
+    // Click Change Password.
+    await page.getByRole("button", { name: "Change Password" }).click();
 
     // Wait for success message.
     await expect(page.getByText("Password updated successfully.")).toBeVisible({
@@ -464,7 +464,7 @@ test.describe.serial("Full user journey", () => {
     });
 
     // Close the settings modal.
-    await page.getByRole("button", { name: "Back" }).click();
+    await page.getByRole("button", { name: "Close settings" }).click();
     await expect(
       page.getByRole("heading", { name: "Edit Account Info" })
     ).not.toBeVisible();

--- a/passwords/app/src/account/account.js
+++ b/passwords/app/src/account/account.js
@@ -4,7 +4,15 @@ import { QueryAccount, NewAccount } from "./passwords";
 import { apiGetBucketKeys } from "../api";
 import { showLoader, hideLoader } from "../loader/loader";
 import { errorColor, backgroundColor } from "../theme";
-import { ACCENT, INK } from "./styles";
+import { ACCENT, INK, primarySmallButtonSx } from "./styles";
+import {
+  biometricLabel,
+  isBiometricAvailable,
+  isBiometricEnrolled,
+  isBiometricPromoDismissed,
+  dismissBiometricPromo,
+  enrollBiometric,
+} from "../crypto/biometric";
 import "./account.css";
 import userIcon from "../assets/icons/user-inverted.png";
 import Fab from "@mui/material/Fab";
@@ -18,6 +26,8 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
+import Button from "@mui/material/Button";
+import Snackbar from "@mui/material/Snackbar";
 
 const TOGGLE_VIEW_DELAY_IN_MS = 300;
 const ERROR_MSG_TIME_IN_MS = 10000;
@@ -88,6 +98,53 @@ export default function Account({
     }, ERROR_MSG_TIME_IN_MS);
     setErrorMsgHook(msg);
   }, []);
+
+  // Offer biometric unlock once per login for users who haven't set it up
+  // and haven't said "Not now". "offer" shows Enable / Not now; "done"
+  // confirms after a successful enrollment.
+  const [bioPromo, setBioPromo] = useState(null);
+  useEffect(() => {
+    if (isBiometricEnrolled() || isBiometricPromoDismissed()) return;
+    let cancelled = false;
+    isBiometricAvailable().then((ok) => {
+      if (ok && !cancelled) setBioPromo("offer");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const enableBiometricFromPromo = async () => {
+    try {
+      await enrollBiometric({
+        username,
+        en_user,
+        aesKey: currAesKey,
+        en_pw: currEnPw,
+      });
+      setBioPromo("done");
+    } catch (e) {
+      // A cancelled OS prompt keeps the offer available on the next login;
+      // "Not now" is the only way to opt out of seeing it.
+      setBioPromo(null);
+      if (!(e && e.name === "NotAllowedError")) {
+        setErrorMsg(`Unable to turn on ${biometricLabel()}.`);
+      }
+    }
+  };
+
+  const declineBiometricPromo = () => {
+    dismissBiometricPromo();
+    setBioPromo(null);
+  };
+
+  // If the user enrolls from the settings modal while the offer is up,
+  // retire the offer instead of re-showing it when settings closes.
+  useEffect(() => {
+    if (!showSettings && bioPromo === "offer" && isBiometricEnrolled()) {
+      setBioPromo(null);
+    }
+  }, [showSettings, bioPromo]);
 
   const setQueryView = (b) => {
     showLoader();
@@ -227,6 +284,52 @@ export default function Account({
         setEnPassword={setCurrEnPw}
         show={showSettings}
         stopShowing={() => setShowSettings(false)}
+      />
+      {/* Top-center so it never collides with the bottom "Copied …"
+          snackbars; auto-hiding is not a permanent dismissal ("Not now" is). */}
+      <Snackbar
+        open={bioPromo !== null && !showSettings}
+        autoHideDuration={bioPromo === "done" ? 5000 : 15000}
+        onClose={(e, reason) => reason !== "clickaway" && setBioPromo(null)}
+        message={
+          bioPromo === "done"
+            ? `${biometricLabel()} turned on.`
+            : `Use ${biometricLabel()} instead of your password next time?`
+        }
+        action={
+          bioPromo === "done" ? (
+            <Button
+              sx={primarySmallButtonSx}
+              color="primary"
+              variant="contained"
+              size="small"
+              onClick={() => setBioPromo(null)}
+            >
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button
+                sx={primarySmallButtonSx}
+                color="primary"
+                variant="contained"
+                size="small"
+                onClick={enableBiometricFromPromo}
+              >
+                Enable
+              </Button>
+              <Button
+                color="inherit"
+                size="small"
+                sx={{ marginLeft: "8px" }}
+                onClick={declineBiometricPromo}
+              >
+                Not now
+              </Button>
+            </>
+          )
+        }
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
       />
     </div>
   );

--- a/passwords/app/src/account/settings/settings.css
+++ b/passwords/app/src/account/settings/settings.css
@@ -16,14 +16,6 @@
     padding-top: 28px;
 }
 
-.Settings-modal .buttons {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-    gap: 20px;
-    padding: 10px;
-}
-
 .Settings-modal .disabled {
     padding: 2px;
     background-color:rgba(200, 200, 200, 0.96);
@@ -42,7 +34,7 @@
 .Settings-modal .msg {
     visibility: visible;
     justify-items: end;
-    padding-bottom: 25px;
+    padding: 0 10px 6px;
     text-align: center;
 }
 

--- a/passwords/app/src/account/settings/settings.js
+++ b/passwords/app/src/account/settings/settings.js
@@ -2,6 +2,11 @@ import { useState, useEffect } from "react";
 import Modal from "react-modal";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import Divider from "@mui/material/Divider";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
 import { showLoader, hideLoader } from "../../loader/loader";
 import {
   encryptMaster,
@@ -9,6 +14,13 @@ import {
   changePasswordWithKey,
   checkPassword,
 } from "../../crypto/encrypt";
+import {
+  biometricLabel,
+  isBiometricAvailable,
+  isBiometricEnrolled,
+  enrollBiometric,
+  clearBiometricEnrollment,
+} from "../../crypto/biometric";
 import "./settings.css";
 
 const customStyles = {
@@ -50,10 +62,40 @@ export default function SettingsModal({
   const [errorMsg, setErrorMsg] = useState("");
   const [msg, setMsg] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [bioAvailable, setBioAvailable] = useState(false);
+  const [bioEnrolled, setBioEnrolled] = useState(isBiometricEnrolled());
 
   useEffect(() => {
     Modal.setAppElement("#account-root");
   });
+
+  useEffect(() => {
+    isBiometricAvailable().then(setBioAvailable);
+  }, []);
+
+  const enableBiometric = async () => {
+    try {
+      await enrollBiometric({
+        username,
+        en_user,
+        aesKey: currAesKey,
+        en_pw: pw,
+      });
+      setBioEnrolled(true);
+      setErrorMsg("");
+    } catch (e) {
+      if (e && e.name === "NotAllowedError") {
+        return; // user dismissed the biometric prompt
+      }
+      setMsg("");
+      setErrorMsg(`Unable to turn on ${biometricLabel()}.`);
+    }
+  };
+
+  const disableBiometric = () => {
+    clearBiometricEnrollment();
+    setBioEnrolled(false);
+  };
 
   const trySave = async () => {
     if (newPw !== newPw2) {
@@ -84,7 +126,20 @@ export default function SettingsModal({
       setPw(newPwTry);
       setAesKey(newAesKey);
       setEnPassword(newPwTry);
-      setMsg(<div className="green">Password updated successfully.</div>);
+      // The biometric enrollment caches the old credentials — clear it
+      // rather than serve a stale unlock.
+      if (isBiometricEnrolled()) {
+        clearBiometricEnrollment();
+        setBioEnrolled(false);
+        setMsg(
+          <div className="green">
+            Password updated successfully. {biometricLabel()} was turned off
+            — re-enable it above.
+          </div>
+        );
+      } else {
+        setMsg(<div className="green">Password updated successfully.</div>);
+      }
     } else {
       setMsg("");
       setErrorMsg("Unable to update password.");
@@ -113,6 +168,21 @@ export default function SettingsModal({
         closeTimeoutMS={200}
       >
         <div className="Settings-modal">
+          <Tooltip title="Close">
+            <IconButton
+              aria-label="Close settings"
+              onClick={closeModal}
+              sx={{
+                position: "absolute",
+                top: "10px",
+                right: "10px",
+                color: "rgba(200, 200, 200, 0.96)",
+                ":hover": { color: "white" },
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
           <h2 style={{ alignSelf: "center" }}>Edit Account Info</h2>
           <div className="row">
             <div>
@@ -142,6 +212,59 @@ export default function SettingsModal({
               />
             </div>
           </div>
+          {bioAvailable && (
+            <div className="row">
+              <div style={{ width: "100%", gap: "8px", alignItems: "center" }}>
+                <Button
+                  variant="outlined"
+                  type="button"
+                  disabled={bioEnrolled}
+                  startIcon={bioEnrolled ? <CheckIcon /> : undefined}
+                  sx={{
+                    flexGrow: 1,
+                    height: "45px",
+                    borderRadius: "8px",
+                    fontWeight: "bold",
+                    color: "white",
+                    borderColor: "rgba(200, 200, 200, 0.96)",
+                    ":hover": {
+                      backgroundColor: "#3f50b5",
+                      borderColor: "rgba(200, 200, 200, 0.96)",
+                    },
+                    "&.Mui-disabled": {
+                      color: "rgb(82, 165, 82)",
+                      borderColor: "rgba(200, 200, 200, 0.4)",
+                    },
+                  }}
+                  onClick={enableBiometric}
+                >
+                  {bioEnrolled
+                    ? `${biometricLabel()} enabled`
+                    : `Use ${biometricLabel()}`}
+                </Button>
+                {bioEnrolled && (
+                  <Tooltip title={`Turn off ${biometricLabel()}`}>
+                    <IconButton
+                      aria-label={`Turn off ${biometricLabel()}`}
+                      onClick={disableBiometric}
+                      sx={{
+                        color: "rgba(200, 200, 200, 0.96)",
+                        ":hover": { color: "white" },
+                      }}
+                    >
+                      <CloseIcon />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </div>
+            </div>
+          )}
+          <Divider
+            sx={{
+              borderColor: "rgba(200, 200, 200, 0.25)",
+              margin: "16px 10px 6px",
+            }}
+          />
           <div className="row">
             <div>
               <TextField
@@ -206,31 +329,12 @@ export default function SettingsModal({
             <div>{msg}</div>
             <div className="error">{errorMsg}</div>
           </div>
-          <div className="buttons">
+          <div className="row">
             <Button
               variant="outlined"
               type="button"
               sx={{
-                width: "50%",
-                height: "45px",
-                borderRadius: "8px",
-                ":hover": {
-                  backgroundColor: "#3f50b5",
-                  borderColor: "rgba(200, 200, 200, 0.96)",
-                },
-                borderColor: "rgba(200, 200, 200, 0.96)",
-                fontWeight: "bold",
-                color: "white",
-              }}
-              onClick={closeModal}
-            >
-              Back
-            </Button>
-            <Button
-              variant="outlined"
-              type="button"
-              sx={{
-                width: "50%",
+                width: "100%",
                 height: "45px",
                 borderRadius: "8px",
                 ":hover": {
@@ -243,7 +347,7 @@ export default function SettingsModal({
               }}
               onClick={trySave}
             >
-              Save
+              Change Password
             </Button>
           </div>
         </div>

--- a/passwords/app/src/account/signIn.js
+++ b/passwords/app/src/account/signIn.js
@@ -1,8 +1,15 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { errorColor, backgroundColor } from "../theme";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import { encryptMaster, shaHash, checkPassword } from "../crypto/encrypt";
+import {
+  biometricLabel,
+  isBiometricEnrolled,
+  unlockBiometric,
+  clearBiometricEnrollment,
+} from "../crypto/biometric";
 import { apiCreateUser, apiVerifyUser } from "../api";
 import { showLoader, hideLoader } from "../loader/loader";
 import { KeyBinds } from "../util";
@@ -11,6 +18,11 @@ import "./account.css";
 
 const ERROR_MSG_TIME_IN_MS = 10000;
 const TOGGLE_CREATE_ACCOUNT_DELAY_IN_MS = 300;
+
+// Biometric unlock auto-fires at most once per page load: returning to the
+// sign-in screen (log out, cancelled prompt) must never re-prompt — cancel
+// means "I want to type my password". Module-level so it survives remounts.
+let autoUnlockAttempted = false;
 
 export default function SignIn({ user, backend, setAccountInfo }) {
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
@@ -23,6 +35,60 @@ export default function SignIn({ user, backend, setAccountInfo }) {
   };
   const [username, setUsername] = useState(user);
   const [password, setPasswordHook] = useState("");
+  const [biometricEnrolled, setBiometricEnrolled] = useState(
+    isBiometricEnrolled()
+  );
+
+  const biometricUnlock = async () => {
+    showLoader();
+    let info;
+    try {
+      info = await unlockBiometric();
+    } catch (e) {
+      hideLoader();
+      if (e && e.name === "NotAllowedError") {
+        // User dismissed the biometric prompt — keep the enrollment.
+        return;
+      }
+      // Credential gone or blob undecryptable — enrollment is dead weight.
+      clearBiometricEnrollment();
+      setBiometricEnrolled(false);
+      setErrorMsg(
+        `${biometricLabel()} is no longer set up. Please sign in with your password.`
+      );
+      return;
+    }
+    try {
+      await apiVerifyUser(backend, { en_user: info.en_user, en_pw: info.en_pw });
+      setAccountInfo(info.username, info.en_user, info.aesKey, info.en_pw);
+    } catch (e) {
+      if (/status 4\d\d/.test(e.message)) {
+        // Server rejected the cached credentials (e.g. the master password
+        // changed elsewhere) — the enrollment is stale.
+        clearBiometricEnrollment();
+        setBiometricEnrolled(false);
+        setErrorMsg(
+          `${biometricLabel()} is out of date. Please sign in with your password.`
+        );
+      } else {
+        setErrorMsg("Unable to log in, please try again.");
+      }
+    } finally {
+      hideLoader();
+    }
+  };
+
+  useEffect(() => {
+    const shouldAttempt = !autoUnlockAttempted && biometricEnrolled;
+    autoUnlockAttempted = true;
+    if (shouldAttempt) {
+      // Browsers may refuse a WebAuthn prompt with no user gesture; that
+      // surfaces as NotAllowedError, which biometricUnlock treats as a
+      // cancel — the button and password form remain the fallback.
+      biometricUnlock();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   let submit = () => {
     if (username === "" || password === "") {
@@ -144,6 +210,27 @@ export default function SignIn({ user, backend, setAccountInfo }) {
       >
         {isCreatingAccount ? "Sign up" : "Log In"}
       </Button>
+      {!isCreatingAccount && biometricEnrolled && (
+        <Button
+          variant="outlined"
+          type="button"
+          startIcon={<FingerprintIcon />}
+          sx={{
+            ...primaryButtonSx,
+            marginTop: "12px",
+            backgroundColor: "transparent",
+            color: ACCENT,
+            borderColor: ACCENT,
+            ":hover": {
+              borderColor: ACCENT,
+              backgroundColor: "rgba(63, 80, 181, 0.08)",
+            },
+          }}
+          onClick={biometricUnlock}
+        >
+          Use {biometricLabel()}
+        </Button>
+      )}
       {isCreatingAccount ? (
         <p style={{ fontSize: "18px" }}>
           Have an account already? Log in{" "}

--- a/passwords/app/src/crypto/biometric.js
+++ b/passwords/app/src/crypto/biometric.js
@@ -1,0 +1,196 @@
+// Biometric ("Touch ID / Face ID") unlock via WebAuthn PRF.
+//
+// The passkey is never registered with the backend — it exists purely as a
+// device-bound key-wrapping oracle. Enrollment creates a platform passkey
+// with the PRF extension, derives an AES-GCM key from the PRF output, and
+// stores the signed-in account info (username, en_user, aesKey, en_pw)
+// encrypted in localStorage. Unlock re-evaluates the PRF (which is what
+// triggers the Touch ID / Face ID prompt) and decrypts.
+//
+// Without a successful biometric assertion the PRF output — and therefore
+// the wrapping key — is unobtainable, so the localStorage blob alone is
+// useless to an attacker. The master password itself is never stored.
+//
+// Single-slot: enrolling overwrites any previous enrollment (one account
+// per browser profile).
+
+const STORAGE_KEY = "mapopass.biometric.v1";
+const PROMO_KEY = "mapopass.biometric.promo-dismissed";
+const HKDF_INFO = "mapopass biometric unlock v1";
+
+function toB64url(bytes) {
+  return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromB64url(str) {
+  const b64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+/** User-facing name for the platform's biometric, best-effort from the UA. */
+export function biometricLabel() {
+  const ua = navigator.userAgent;
+  if (/iPhone|iPad|iPod/.test(ua)) return "Face ID";
+  if (/Macintosh/.test(ua)) return "Touch ID";
+  return "biometrics";
+}
+
+export function isBiometricEnrolled() {
+  return localStorage.getItem(STORAGE_KEY) !== null;
+}
+
+export function clearBiometricEnrollment() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Whether the user said "Not now" to the post-login enable-unlock offer. */
+export function isBiometricPromoDismissed() {
+  return localStorage.getItem(PROMO_KEY) !== null;
+}
+
+export function dismissBiometricPromo() {
+  localStorage.setItem(PROMO_KEY, "1");
+}
+
+/** True when the browser has a user-verifying platform authenticator. */
+export async function isBiometricAvailable() {
+  if (!window.PublicKeyCredential) return false;
+  try {
+    return await window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+  } catch {
+    return false;
+  }
+}
+
+async function deriveAesKey(prfOutput, hkdfSalt) {
+  const material = await crypto.subtle.importKey(
+    "raw",
+    prfOutput,
+    "HKDF",
+    false,
+    ["deriveKey"]
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: hkdfSalt,
+      info: new TextEncoder().encode(HKDF_INFO),
+    },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+/** Evaluate the passkey's PRF at prfSalt — this is the biometric prompt. */
+async function evalPrf(credentialId, prfSalt) {
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [{ type: "public-key", id: credentialId }],
+      userVerification: "required",
+      extensions: { prf: { eval: { first: prfSalt } } },
+    },
+  });
+  const prfOutput = assertion.getClientExtensionResults().prf?.results?.first;
+  if (!prfOutput) {
+    throw new Error("Authenticator did not return a PRF result.");
+  }
+  return prfOutput;
+}
+
+/**
+ * Create a passkey and store the account info encrypted under its PRF.
+ * Prompts for biometrics (twice on browsers that can't evaluate the PRF
+ * at creation time). Throws on unsupported authenticators or user cancel.
+ */
+export async function enrollBiometric({ username, en_user, aesKey, en_pw }) {
+  const prfSalt = crypto.getRandomValues(new Uint8Array(32));
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      rp: { name: "MapoPass" },
+      // Generic identity: the real username is client-side-hashed before it
+      // ever leaves the app, so it must not leak into the passkey metadata
+      // that syncs to iCloud Keychain.
+      user: {
+        id: crypto.getRandomValues(new Uint8Array(16)),
+        name: "MapoPass unlock",
+        displayName: "MapoPass unlock",
+      },
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 }, // ES256
+        { type: "public-key", alg: -257 }, // RS256
+      ],
+      authenticatorSelection: {
+        authenticatorAttachment: "platform",
+        residentKey: "preferred",
+        userVerification: "required",
+      },
+      extensions: { prf: { eval: { first: prfSalt } } },
+    },
+  });
+
+  const ext = credential.getClientExtensionResults();
+  let prfOutput = ext.prf?.results?.first;
+  if (!prfOutput) {
+    if (!ext.prf?.enabled) {
+      clearBiometricEnrollment();
+      throw new Error("This device's passkeys do not support PRF.");
+    }
+    // Authenticator supports PRF but couldn't evaluate during create();
+    // evaluate with a follow-up assertion (second biometric prompt).
+    prfOutput = await evalPrf(credential.rawId, prfSalt);
+  }
+
+  const hkdfSalt = crypto.getRandomValues(new Uint8Array(32));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveAesKey(prfOutput, hkdfSalt);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(
+      JSON.stringify({ username, en_user, aesKey, en_pw })
+    )
+  );
+
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      credentialId: toB64url(credential.rawId),
+      prfSalt: toB64url(prfSalt),
+      hkdfSalt: toB64url(hkdfSalt),
+      iv: toB64url(iv),
+      ciphertext: toB64url(ciphertext),
+    })
+  );
+}
+
+/**
+ * Prompt for biometrics and return the decrypted account info
+ * ({ username, en_user, aesKey, en_pw }). Throws if not enrolled, on user
+ * cancel (NotAllowedError), or if the stored blob can't be decrypted.
+ */
+export async function unlockBiometric() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === null) {
+    throw new Error("Biometric unlock is not set up.");
+  }
+  const enrollment = JSON.parse(raw);
+  const prfOutput = await evalPrf(
+    fromB64url(enrollment.credentialId),
+    fromB64url(enrollment.prfSalt)
+  );
+  const key = await deriveAesKey(prfOutput, fromB64url(enrollment.hkdfSalt));
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: fromB64url(enrollment.iv) },
+    key,
+    fromB64url(enrollment.ciphertext)
+  );
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}

--- a/passwords/app/src/crypto/biometric.test.js
+++ b/passwords/app/src/crypto/biometric.test.js
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the WebAuthn-PRF biometric unlock module.
+ *
+ * jsdom ships neither WebAuthn nor WebCrypto, so both are simulated:
+ * `crypto` comes from Node's webcrypto, and `navigator.credentials` is a
+ * fake platform authenticator whose PRF is HMAC-SHA256(deviceSecret, salt) —
+ * deterministic per credential, unknowable without the device secret, which
+ * is exactly the contract the real extension provides.
+ */
+import { webcrypto } from "crypto";
+import { TextEncoder, TextDecoder } from "util";
+import {
+  isBiometricEnrolled,
+  clearBiometricEnrollment,
+  enrollBiometric,
+  unlockBiometric,
+} from "./biometric";
+
+const ACCOUNT = {
+  username: "maple",
+  en_user: "abc123hasheduser",
+  aesKey: "deadbeef".repeat(8),
+  en_pw: "0123456789abcdef",
+};
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "crypto", {
+    value: webcrypto,
+    configurable: true,
+  });
+  global.TextEncoder = TextEncoder;
+  global.TextDecoder = TextDecoder;
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+async function prf(deviceSecret, salt) {
+  const key = await webcrypto.subtle.importKey(
+    "raw",
+    deviceSecret,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return webcrypto.subtle.sign("HMAC", key, salt);
+}
+
+/**
+ * Install a fake platform authenticator on navigator.credentials.
+ * `prfAtCreate: false` simulates browsers (e.g. older Chrome) that report
+ * prf.enabled at create() but only evaluate on a follow-up get().
+ */
+function installFakeAuthenticator({ prfAtCreate = true } = {}) {
+  const deviceSecret = webcrypto.getRandomValues(new Uint8Array(32));
+  const credId = webcrypto.getRandomValues(new Uint8Array(16));
+  const fake = {
+    async create(options) {
+      const salt = options.publicKey.extensions.prf.eval.first;
+      const results = prfAtCreate
+        ? { first: await prf(deviceSecret, salt) }
+        : undefined;
+      return {
+        rawId: credId.buffer.slice(0),
+        getClientExtensionResults: () => ({
+          prf: { enabled: true, ...(results ? { results } : {}) },
+        }),
+      };
+    },
+    async get(options) {
+      const allowed = new Uint8Array(options.publicKey.allowCredentials[0].id);
+      if (Buffer.compare(Buffer.from(allowed), Buffer.from(credId)) !== 0) {
+        const err = new Error("credential not found");
+        err.name = "NotAllowedError";
+        throw err;
+      }
+      const salt = options.publicKey.extensions.prf.eval.first;
+      const first = await prf(deviceSecret, salt);
+      return { getClientExtensionResults: () => ({ prf: { results: { first } } }) };
+    },
+  };
+  Object.defineProperty(window.navigator, "credentials", {
+    value: fake,
+    configurable: true,
+  });
+}
+
+test("enroll then unlock round-trips the account info", async () => {
+  installFakeAuthenticator();
+  expect(isBiometricEnrolled()).toBe(false);
+  await enrollBiometric(ACCOUNT);
+  expect(isBiometricEnrolled()).toBe(true);
+  expect(await unlockBiometric()).toEqual(ACCOUNT);
+});
+
+test("enroll works when PRF is only available on a follow-up get()", async () => {
+  installFakeAuthenticator({ prfAtCreate: false });
+  await enrollBiometric(ACCOUNT);
+  expect(await unlockBiometric()).toEqual(ACCOUNT);
+});
+
+test("stored blob does not contain any secret in plaintext", async () => {
+  installFakeAuthenticator();
+  await enrollBiometric(ACCOUNT);
+  const blob = localStorage.getItem("mapopass.biometric.v1");
+  expect(blob).not.toBeNull();
+  for (const secret of Object.values(ACCOUNT)) {
+    expect(blob).not.toContain(secret);
+  }
+});
+
+test("unlock fails if the stored ciphertext is tampered with", async () => {
+  installFakeAuthenticator();
+  await enrollBiometric(ACCOUNT);
+  const blob = JSON.parse(localStorage.getItem("mapopass.biometric.v1"));
+  blob.ciphertext =
+    (blob.ciphertext[0] === "A" ? "B" : "A") + blob.ciphertext.slice(1);
+  localStorage.setItem("mapopass.biometric.v1", JSON.stringify(blob));
+  await expect(unlockBiometric()).rejects.toThrow();
+});
+
+test("clearing the enrollment makes unlock impossible", async () => {
+  installFakeAuthenticator();
+  await enrollBiometric(ACCOUNT);
+  clearBiometricEnrollment();
+  expect(isBiometricEnrolled()).toBe(false);
+  await expect(unlockBiometric()).rejects.toThrow(
+    "Biometric unlock is not set up."
+  );
+});
+
+test("a different authenticator cannot unlock (fresh device secret)", async () => {
+  installFakeAuthenticator();
+  await enrollBiometric(ACCOUNT);
+  // Same credential id would be a NotAllowedError; simulate the worst case —
+  // an authenticator that answers for the credential but with a different
+  // device secret. Decryption must fail.
+  const blob = JSON.parse(localStorage.getItem("mapopass.biometric.v1"));
+  const otherSecret = webcrypto.getRandomValues(new Uint8Array(32));
+  Object.defineProperty(window.navigator, "credentials", {
+    configurable: true,
+    value: {
+      async get(options) {
+        const salt = options.publicKey.extensions.prf.eval.first;
+        const first = await prf(otherSecret, salt);
+        return {
+          getClientExtensionResults: () => ({ prf: { results: { first } } }),
+        };
+      },
+    },
+  });
+  expect(localStorage.getItem("mapopass.biometric.v1")).toBe(
+    JSON.stringify(blob)
+  );
+  await expect(unlockBiometric()).rejects.toThrow();
+});


### PR DESCRIPTION
## What

Touch ID / Face ID unlock for MapoPass, implemented entirely client-side with the WebAuthn PRF extension — no server changes, no new endpoints.

**How it works:** enrollment creates a platform passkey whose PRF output (Secure-Enclave-backed) is run through HKDF into an AES-GCM key that encrypts the signed-in credentials (`username`, `en_user`, `aesKey`, `en_pw`) into localStorage. Unlocking re-evaluates the PRF — that's the OS biometric prompt — and decrypts. The passkey is never registered with the backend; the master password is never stored; the localStorage blob is useless without a biometric assertion. The plaintext username lives only inside the ciphertext (usernames are client-side-hashed secrets, so they must not leak into passkey metadata or storage).

## UX

- **Sign-in:** "Use Touch ID" (Face ID on iPhone) button when enrolled. Auto-fires once per page load — never after logout or a cancelled prompt (cancel means "I want to type"). Stale enrollments (master password changed elsewhere, passkey deleted) self-clear with an explanatory message; network failures don't destroy the enrollment.
- **Settings:** biometric control sits with the username, separated from the password form by a divider. Un-enrolled it's a "Use Touch ID" button; enrolled it flips to a disabled green-check "Touch ID enabled" with an X (tooltip "Turn off Touch ID"). Back/Save row replaced by a corner X to close and a full-width "Change Password" button owned by the password form.
- **Post-login offer:** top-center snackbar (never collides with the bottom copy snackbars) offering enrollment; "Not now" opts out per device, and the offer retires itself if you enroll from settings while it's up.
- Changing the master password clears the enrollment (cached credentials would be stale) and says so.

## Security notes

- Biometrics gate a cached secret; they don't replace the master password. First login always requires the password.
- The biometric check is the OS's: any fingerprint/face enrolled on the device can unlock the enrolled account. Trust boundary = the OS user account (same model as 1Password/Bitwarden).
- Single enrollment slot per browser profile; enrolling overwrites.
- Requires PRF support: Chrome, or Safari on macOS 15 / iOS 18+. Unsupported browsers get a clean error and everything else keeps working.

## Testing

- 6 unit tests simulate a PRF authenticator (HMAC over a device secret): round-trip, tamper rejection, wrong-authenticator rejection, no plaintext secrets in storage.
- 8-scenario e2e journey via Chromium's CDP virtual authenticator (`hasPrf`): sign-up offer, settings enroll/disable, manual unlock, no-auto-fire-after-logout, reload auto-unlock with zero clicks, password change clearing enrollment, offer Enable path, offer retiring after settings enroll.
- Full suites green: 41/41 unit, 24/24 e2e, clean `CI=true` build.